### PR TITLE
Setup active storage defaults

### DIFF
--- a/config/initializers/default_url_options.rb
+++ b/config/initializers/default_url_options.rb
@@ -1,0 +1,8 @@
+hosts = {
+  development: "https://localhost",
+  staging:     "https://#{@app_name}-staging.katalyst.com.au",
+  production:  "https://#{@app_name}-production.katalyst.com.au",
+  test:        "https://example.com",
+}.freeze
+
+Rails.application.routes.default_url_options = { host: hosts[Rails.env.to_sym] }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,9 @@ Rails.application.routes.draw do
   resource :homepage, only: %i[show]
 
   root "homepages#show"
+
+  unless Rails.env.development? || Rails.env.test?
+    put "/rails/active_storage/disk/:encoded_token", to: redirect("/404")
+  end
+  post "/rails/active_storage/direct_uploads", to: redirect("/404")
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -5,3 +5,10 @@ test:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
+
+s3:
+  service: S3
+  region: ap-southeast-2
+  access_key_id: <%= ENV["RAILS_ASSETS_ACCESS_KEY"] %>
+  secret_access_key: <%= ENV["RAILS_ASSETS_SECRET_KEY"] %>
+  bucket: <%= ENV.fetch("RAILS_ASSETS_BUCKET_ID", "[DEFAULT_BUCKET_ID]") %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,7 +10,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # require "webmock/rspec"
 require "shoulda/matchers"
-# require "active_storage_validations/matchers"
+require "active_storage_validations/matchers"
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
@@ -30,7 +30,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
 
-  # config.include ActiveStorageValidations::Matchers
+  config.include ActiveStorageValidations::Matchers
   config.include FactoryBot::Syntax::Methods
   # config.include Koi::Controller::HasAdminUsers::Test::ViewHelper, type: :view
   # config.include SystemHelper, type: :system

--- a/templates/koi.rb
+++ b/templates/koi.rb
@@ -2,6 +2,14 @@
 
 gem("koi", github: "katalyst/koi")
 
+# setup aws s3 gem
+gem "aws-sdk-s3", require: false
+
+# setup image processing gem for variants etc
+gem "image_processing"
+
+gem "active_storage_validations"
+
 # koi requires action_text
 uncomment_lines("config/application.rb", /action_text/)
 uncomment_lines("config/application.rb", /action_mailer/)
@@ -12,8 +20,6 @@ append_file("db/seeds.rb", "Koi::Engine.load_seed")
 
 # adds navigation items to admin menu
 template("config/initializers/koi.rb")
-
-copy_file("config/storage.yml")
 
 root = Pathname.new(__dir__).join("..")
 root.glob("app/{controllers}/admin/**/*.rb").sort.each do |f|


### PR DESCRIPTION
1. Installs `active_storage` migrations
2. Disables direct upload routes
```ruby
unless Rails.env.development? || Rails.env.test?
  put "/rails/active_storage/disk/:encoded_token", to: redirect("/404")
end
post "/rails/active_storage/direct_uploads", to: redirect("/404")
```
3. Configures service for `active_storage` in environments
```ruby
Rails.application.configure do
  config.active_storage.service = :s3
end
```
4. Adds `aws-sdk-s3` gem for AWS S3
5. Adds `image_processing` for variant support
6. Configures AWS S3 with defaults
```yaml
s3:
  service: S3
  region: ap-southeast-2
  access_key_id: <%= ENV["RAILS_ASSETS_ACCESS_KEY"] %>
  secret_access_key: <%= ENV["RAILS_ASSETS_SECRET_KEY"] %>
  bucket: <%= ENV.fetch("RAILS_ASSETS_BUCKET_ID", "katalyst-[APP_NAME]-staging-assets") %>
```
7. Adds `host` to `default_url_options`
```ruby
development: "https://localhost",
staging:     "https://#{@app_name}-staging.katalyst.com.au",
production:  "https://#{@app_name}-production.katalyst.com.au",
test:        "https://example.com",
```