### PR TITLE
Feature: skip docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more about ignoring files.
+
+# Ignore git directory.
+/.git/
+
+# Ignore bundler config.
+/.bundle
+
+# Ignore all environment files (except templates).
+/.env*
+!/.env*.erb
+
+# Ignore all default key files.
+/config/master.key
+/config/credentials/*.key
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids/.keep
+
+# Ignore storage (uploaded files in development and any SQLite databases).
+/storage/*
+!/storage/.keep
+/tmp/storage/*
+!/tmp/storage/.keep
+
+# Ignore assets.
+/node_modules/
+/app/assets/builds/*
+!/app/assets/builds/.keep
+/public/assets

--- a/APPREADME.md
+++ b/APPREADME.md
@@ -5,7 +5,7 @@ Katalyst project for <%= @app_name %>.
 ## Development
 
 To run the rails server as well as watching for dartsass changes, the
-application provides a Procfile (ran through foreman) to use this, run `bin/dev`
+application provides a Procfile (run through foreman) to use this, run `bin/dev`
 then visit `localhost`.
 
 ### Admin

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ rails new sprint0 -d postgresql \
             --skip-active-job \
             --skip-bootsnap \
             --skip-dev-gems \
+            --skip-docker \
             --skip-jbuilder \
             --skip-system-test \
             --skip-test \
@@ -38,16 +39,17 @@ rails new sprint0 -d postgresql \
 ```
 
  * subset of --minimal configuration
-   * --skip_action_cable: we're not providing support for action_cable
-   * --skip_action_mailer: we're not providing support for action_mailer
-   * --skip_action_mailbox: we're not providing support for action_mailbox
-   * --skip_active_job: we're not providing support for active_job
-   * --skip_bootsnap: we're not using bootsnap
-   * --skip_dev_gems: we do not need dev gems
-   * --skip_jbuilder: we do not need jbuilder
-   * --skip_system_test: we have set up system tests with rspec and cuprite 
+   * --skip-action-cable: we're not providing support for action_cable
+   * --skip-action-mailer: we're not providing support for action_mailer
+   * --skip-action-mailbox: we're not providing support for action_mailbox
+   * --skip-active-job: we're not providing support for active_job
+   * --skip-bootsnap: we're not using bootsnap
+   * --skip-dev-gems: we do not need dev gems
+   * --skip-jbuilder: we do not need jbuilder
+   * --skip-system-test: we have set up system tests with rspec and cuprite
  * --skip-test: we have set up rspec
  * --skip-bundle: we run bundle ourselves once gems are added
+ * --skip-docker: we generate our own docker configuration
  * --skip-git: we have set up git to point to Katalyst github
  * --skip-keeps: we only create the keep files we need
  * -a propshaft: we use propshaft for asset pipeline

--- a/template.rb
+++ b/template.rb
@@ -232,6 +232,7 @@ end
 
 def add_docker
   directory("docker", mode: :preserve)
+  template(".dockerignore")
 end
 
 def configure_git


### PR DESCRIPTION
We generate our own docker configuration, so skip the files generated by rails (we have a copy of `.dockerignore` included though).