### PR TITLE
Add s3 storage config

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -5,3 +5,10 @@ test:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
+
+s3:
+  service: S3
+  region: ap-southeast-2
+  access_key_id: <%= ENV["RAILS_ASSETS_ACCESS_KEY"] %>
+  secret_access_key: <%= ENV["RAILS_ASSETS_SECRET_KEY"] %>
+  bucket: <%= ENV.fetch("RAILS_ASSETS_BUCKET_ID", nil) %>

--- a/template.rb
+++ b/template.rb
@@ -24,6 +24,7 @@ def apply_template!
   setup_release_tag
   setup_routes
   setup_ecs
+  setup_aws_s3
 
   cleanup_gemfile
 
@@ -260,6 +261,10 @@ end
 
 def setup_ecs
   template("config/ecs.env")
+end
+
+def setup_aws_s3
+  gem("aws-sdk-s3")
 end
 
 apply_template!


### PR DESCRIPTION
I've ran into this the last few times we've booted up a new Koi site. 
As per the docs in the Sprint0 playbook these ENV vars will be set up in the infrastructure pipeline. 