### PR TITLE
Optionally add koi during command runtime

### DIFF
--- a/APPREADME.md
+++ b/APPREADME.md
@@ -8,6 +8,7 @@ To run the rails server as well as watching for dartsass changes, the
 application provides a Procfile (run through foreman) to use this, run `bin/dev`
 then visit `localhost`.
 
+<% if @add_koi %>
 ### Admin
 
 Koi has been mounted automatically at `/admin`, which can be configured via the
@@ -24,7 +25,7 @@ bin/admin-adduser
 If your username matches your Katalyst email address then when you're running
 locally with local admin enabled in AdminController then you will be
 automatically signed in as yourself. 
-
+<% end %>
 ### Prerequisites
 
 This project uses:
@@ -33,7 +34,7 @@ This project uses:
   - [Ruby on Rails](https://rubyonrails.org/)
   - [Postgres](https://www.postgresql.org/)
   - [RSpec](https://github.com/rspec/rspec-rails)
-  - [Koi](https://github.com/katalyst/koi)
+<% if @add_koi %>- [Koi](https://github.com/katalyst/koi)<% end %>
   - [Rubocop Katalyst](https://github.com/katalyst/rubocop-katalyst)
   - [Katalyst BasicAuth](https://github.com/katalyst/katalyst-basic-auth)
   - [Sentry](https://sentry.io)

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-Koi.config.admin_stylesheet = "admin"
-
 Rails.application.config.dartsass.builds = {
   "application.scss" => "application.css",
-  "admin.scss"       => "admin.css",
 }
 
 Rails.application.config.dartsass.build_options << "--quiet-deps"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,6 @@
 Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
-  draw :admin
-
   resource :homepage, only: %i[show]
 
   root "homepages#show"

--- a/template.rb
+++ b/template.rb
@@ -5,6 +5,8 @@ fail("Rails 7.0.0 or greater is required") if Rails.version <= "7"
 def apply_template!
   add_template_repository_to_source_path
 
+  @add_koi = yes?("Would you like include koi? (y/n)")
+
   setup_readme
   setup_rubocop
   setup_rspec
@@ -19,7 +21,7 @@ def apply_template!
   setup_foreman
   setup_rakefile
   setup_timezone
-  setup_koi
+  setup_koi if @add_koi
   setup_homepage
   setup_release_tag
   setup_routes
@@ -36,7 +38,7 @@ def apply_template!
     install_dartsass
     install_active_storage
     install_flipper
-    install_koi
+    install_koi if @add_koi
 
     remove_unused_files
     override_default_files
@@ -67,10 +69,10 @@ def add_template_repository_to_source_path
     template_root = Dir.mktmpdir("koi-template-")
     at_exit { FileUtils.remove_entry(template_root) }
     git clone: [
-      "--quiet",
-      "https://github.com/katalyst/koi-template.git",
-      template_root,
-    ].map(&:shellescape).join(" ")
+                 "--quiet",
+                 "https://github.com/katalyst/koi-template.git",
+                 template_root,
+               ].map(&:shellescape).join(" ")
 
     if (branch = __FILE__[%r{koi-template/(.+)/template.rb}, 1])
       Dir.chdir(template_root) { git checkout: branch }
@@ -187,12 +189,16 @@ def setup_homepage
 end
 
 def setup_routes
-  directory("config/routes")
+  directory("config/routes") if @add_koi
   template("config/routes.rb", force: true)
 end
 
 def setup_stylesheets
-  directory("app/assets/stylesheets")
+  if @add_koi
+    directory("app/assets/stylesheets")
+  else
+    directory("app/assets/stylesheets", exclude_pattern: /admin.scss/)
+  end
 end
 
 def remove_unused_files

--- a/templates/override-default-files.rb
+++ b/templates/override-default-files.rb
@@ -1,8 +1,16 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-directory("bin", force: true, mode: :preserve)
+if @add_koi
+  directory("bin", force: true, mode: :preserve)
+  directory("spec", force: true, exclude_pattern: /template.rb/)
+  insert_into_file("config/initializers/dartsass.rb", "\"admin.scss\"       => \"admin.css\",", after: "\"application.css\",\n")
+  insert_into_file("config/initializers/dartsass.rb", "Koi.config.admin_stylesheet = \"admin\"", after: "# frozen_string_literal: true\n")
+  route("draw :admin")
+else
+  directory("bin", force: true, mode: :preserve, exclude_pattern: /admin-adduser/)
+  directory("spec", force: true, exclude_pattern: /admin_/)
+  remove_file("spec/template.rb")
+end
 
 directory("public", force: true)
-
-directory("spec", force: true, exclude_pattern: /template.rb/)


### PR DESCRIPTION
We are unable to add additional command line options to the rials new command that get passed into the template. This approach allows us to ask if we would like koi installed as we have been using this template for our non koi based projects as we want to leverage the work to align our projects to Katalyst best practices.

Perhaps if we go down this path we should change the repo name?