### PR TITLE
Miscellanous test github workflow changes

### DIFF
--- a/github/workflows/test.yml
+++ b/github/workflows/test.yml
@@ -18,6 +18,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+#      - name: Install dependencies
+#        env:
+#          DEPENDENCIES="libvips"
+#        run: sudo apt-get install -y $DEPENDENCIES || (sudo apt-get update && sudo apt-get install -y $DEPENDENCIES)
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Setup Ruby and install gems


### PR DESCRIPTION
As part of app-care ™ I have been keeping the github workflows up to date with koi-template (where possible).
These amendments have been made in individual projects (nfsa-pdc and sca).
I found that removing these amendments broke those individual projects' test run. It's possible that these changes could be added in koi-template - this could make it easier to keep them up to date in future