### PR TITLE
Fix docker build for missing $S3_ASSETS_BUCKET

### DIFF
--- a/Dockerfile.tt
+++ b/Dockerfile.tt
@@ -73,7 +73,7 @@ COPY --from=build /rails/public public
 RUN --mount=type=secret,id=aws-key-id,env=AWS_ACCESS_KEY_ID \
     --mount=type=secret,id=aws-secret-key,env=AWS_SECRET_ACCESS_KEY \
     --mount=type=secret,id=aws-session-token,env=AWS_SESSION_TOKEN \
-    if [ -n "$CDN_ASSET_PREFIX" ]; then \
+    if [ -n "$CDN_ASSET_PREFIX" ] && [ -n "$S3_ASSETS_BUCKET" ]; then \
       aws s3 sync --only-show-errors public/$CDN_ASSET_PREFIX s3://$S3_ASSETS_BUCKET/$CDN_ASSET_PREFIX; \
     fi
 


### PR DESCRIPTION
when CDN is not configured, $S3_ASSETS_BUCKET is not set (but CDN_ASSET_PREFIX is)