### PR TITLE
Add github test workflow concurrency

### DIFF
--- a/github/workflows/test.yml
+++ b/github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - '*'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   lint_test:
     runs-on: ubuntu-latest-m


### PR DESCRIPTION
Only run one test per branch at a time.

reason for change: 
I've noticed in other projects after merging two commits to main, there are two tests running (one for each commit). This seems wasteful